### PR TITLE
Tot error bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,4 +7,5 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
-- Initial release.
+### Changed
+- Updated the version renv.lock file to use new version of emulandice2 R pkg that should write correct outputs for single region for AIS ice source. ([PR #16](https://github.com/fact-sealevel/emulandice2/pull/16), [e-marshall](https://github.com/e-marshall))

--- a/scripts/main.R
+++ b/scripts/main.R
@@ -197,6 +197,15 @@ cat(paste("\nModel error for calibration: using",scale_mod_err,"x obs error", "\
 # Calculate combined discrepancy
 total_err <- sqrt(obs_data[,"SLE_sd"]^2 + model_err^2)
 
+# Save for total change e.g. for plots
+# xxx TODO: multiple time periods for IMBIE
+if (i_s == "GLA" && glacier_data == "Hugonnet") { tot_err <- total_err
+} else tot_err <- total_err[obs_data$Year == cal_end]
+
+#cat(paste0("\nObserved change (", cal_start,"-", cal_end, "):\n"), file = logfile_results, append = TRUE)
+#cat(sprintf("%.4f +/- %.4f cm SLE (3 s.d. obs error)\n", obs_change, 3.0*obs_err), file = logfile_results, append = TRUE)
+#cat(sprintf("%.4f +/- %.4f cm SLE (3 s.d. total error)\n", obs_change, 3.0*tot_err), file = logfile_results, append = TRUE)
+
 #' # Option to replot simulations
 # Replot sims -----------------------------------------------------------------------
 


### PR DESCRIPTION
This PR adds lines that are in the current version of `Main.R` in https://github.com/tamsinedwards/emulandice2/blob/main/main.R but not present in https://github.com/fact-sealevel/emulandice2/blob/main/scripts/main.R. 

Lines 205-208 are in the other Main.R file but I commented them out here. They don't seem necessary but, if they're included, it doesn't run for me locally because `obs_change` isn't defined. Not sure how that works in the original? I left them in to track but maybe they could be removed 