### PR TITLE
make lslr-out-file/postprocessing optional

### DIFF
--- a/src/emulandice2/cli.py
+++ b/src/emulandice2/cli.py
@@ -104,7 +104,7 @@ class Region(enum.StrEnum):
     "--output-lslr-file",
     envvar="EMULANDICE2_OUTPUT_LSLR_FILE",
     help="Path to write output local SLR file.",
-    required=True,
+    required=False,
     type=str,
 )
 @click.option(
@@ -257,18 +257,24 @@ def main(
             r_script_path=r_script_path,
         )
 
-        # Takes R output files as input so need to run postprocessing before tmp
-        # working dir gets cleaned up.
-        emulandice_postprocess(
-            locationfile=location_file,
-            chunksize=chunksize,
-            pipeline_id=pipeline_id,
-            ncfiles=r_projected_paths,
-            grdfingerprintfile=grdfingerprintfile,
-            fingerprint_dir=fingerprint_dir,
-            scenario=scenario,
-            baseyear=baseyear,
-            output_lslr_file=output_lslr_file,
-        )
+        if output_lslr_file is not None:
+            logger.info("Starting emulandice2 postprocessing")
+            # Takes R output files as input so need to run postprocessing before tmp
+            # working dir gets cleaned up.
+            emulandice_postprocess(
+                locationfile=location_file,
+                chunksize=chunksize,
+                pipeline_id=pipeline_id,
+                ncfiles=r_projected_paths,
+                grdfingerprintfile=grdfingerprintfile,
+                fingerprint_dir=fingerprint_dir,
+                scenario=scenario,
+                baseyear=baseyear,
+                output_lslr_file=output_lslr_file,
+            )
+        else:
+            logger.info(
+                "No output local SLR file specified, skipping emulandice2 postprocessing"
+            )
 
     logger.info("emulandice2 complete")


### PR DESCRIPTION
This PR is related to https://github.com/fact-sealevel/facts-experiment-builder/issues/70. it makes `lslr-out-file` optional so that global-only experiments can be run. I tested this locally with the following and it ran successfully.

Build container
```shell
docker build -t emulandice2:make_local_optional .
```
Run
```shell
docker run --rm \
  -v ./data:/data \
  emulandice2:make_local_optional \
  --pipeline-id=1234 \
  --ice-source=AIS \
  --region=WAIS \
  --seed=2024 \
  --emu-file="/data/input/emu_file/AIS_WAIS_2300_260512_EMULATOR.RData" \
  --scenario="ssp585" \
  --climate-data-file="/data/input/twolayer_SSPs.h5" \
  --pyear-start=2020 \
  --pyear-end=2300 \
  --location-file="/data/input/location.lst" \
  --grdfingerprintfile="/data/input/grd_fingerprintmap.yml" \
  --fingerprint-dir="/data/input/FPRINT" \
  --output-gslr-file="/data/output/gslr.nc"
```

Close #18 